### PR TITLE
Fix mobile layout for header

### DIFF
--- a/estacionamiento_auto_control.html
+++ b/estacionamiento_auto_control.html
@@ -38,9 +38,9 @@
 <body class="bg-gray-100 font-sans">
     <!-- Encabezado -->
     <header class="bg-blue-600 text-white shadow-md">
-        <div class="container mx-auto px-4 py-4 flex items-center justify-between">
-            <h1 class="text-2xl font-bold">Gestión de Estacionamiento</h1>
-            <div class="space-x-2">
+        <div class="container mx-auto px-4 py-4 flex flex-col sm:flex-row items-center justify-between space-y-2 sm:space-y-0">
+            <h1 class="text-2xl font-bold text-center sm:text-left">Gestión de Estacionamiento</h1>
+            <div class="flex space-x-2">
                 <button id="export-data" class="bg-blue-600 text-white px-3 py-1 rounded-md hover:bg-blue-700 transition duration-200">Exportar Datos</button>
                 <label for="import-file" class="bg-blue-600 text-white px-3 py-1 rounded-md hover:bg-blue-700 transition duration-200 cursor-pointer">Importar Datos<input id="import-file" type="file" accept="application/json" class="hidden"></label>
             </div>


### PR DESCRIPTION
## Summary
- adjust header layout so import/export buttons look correct on mobile

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68631083a070832cacddce1fe37b26cc